### PR TITLE
Update mitogen.yml

### DIFF
--- a/contrib/mitogen/mitogen.yml
+++ b/contrib/mitogen/mitogen.yml
@@ -40,7 +40,7 @@
         path: ansible.cfg
         mode: 0644
         section: "{{ item.section | d('defaults') }}"
-        option: "{{ item.section }}"
+        option: "{{ item.option }}"
         value: "{{ item.value }}"
       with_items:
         - option: strategy


### PR DESCRIPTION
Fixed the problem when call  `ansible-playbook contrib/mitogen/mitogen.yml `
"The error was: 'dict object' has no attribute 'section'"

What type of PR is this?

/kind bug

What this PR does / why we need it:

Which issue(s) this PR fixes:

Fixes #

Special notes for your reviewer:

Does this PR introduce a user-facing change?: